### PR TITLE
Only fail low-coverage in PRs.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
 
       - name: Run Tests
         env:
+          COVERAGE_FAIL_UNDER: ${{ github.event_name == 'pull_request' && '85' || '0' }}
           PY_COLORS: 1
         run: make test
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ exclude_lines = [
     "^\\s*raise AssertionError",
     "^\\s*raise NotImplementedError",
 ]
-fail_under = 85
+fail_under = "${COVERAGE_FAIL_UNDER-0}"
 
 [tool.coverage.run]
 branch = true


### PR DESCRIPTION
It was annoying when working on new features without TDD that tests would keep failing before I added unit tests. I kept commenting out the line in pyproject until I was done.

Updating the boilerplate so that this check only applies during PRs. Makes sense to me.