### PR TITLE
Not creating _thumbs if not needed.

### DIFF
--- a/sphinx_thumb_image/resize.py
+++ b/sphinx_thumb_image/resize.py
@@ -66,7 +66,6 @@ class ThumbImageResize:
         :param doctree: Current document.
         """
         thumbs_dir = app.env.doctreedir / cls.THUMBS_SUBDIR
-        thumbs_dir.mkdir(exist_ok=True)
         doctree_source = Path(doctree["source"])
         doctree_subdir = doctree_source.parent.relative_to(app.srcdir)
         for node in doctree.findall(lambda n: ThumbNodeRequest.KEY in n):


### PR DESCRIPTION
When resizing mkdir is already called with parents=True. No need to create _thumbs before resizing.