### PR TITLE
Fix copy_files, dict to list[tuples]

### DIFF
--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -35,8 +35,8 @@ def _app_params(app_params, request: pytest.FixtureRequest):
     app_params.kwargs.setdefault("freshenv", True)
     srcdir: Path = app_params.kwargs["srcdir"]
     # Implement copy_files.
-    for copy_files in (app_params.kwargs.get("copy_files", {}), getattr(request, "param", {}).get("copy_files", {})):
-        for copy_from, copy_to in copy_files.items():
+    for copy_files in (app_params.kwargs.get("copy_files", []), getattr(request, "param", {}).get("copy_files", [])):
+        for copy_from, copy_to in copy_files:
             source: Path = srcdir / copy_from
             target: Path = srcdir / copy_to
             target.parent.mkdir(exist_ok=True, parents=True)

--- a/tests/unit_tests/test_paths.py
+++ b/tests/unit_tests/test_paths.py
@@ -69,9 +69,9 @@ def test_efficient(outdir: Path, img_tags: list[element.Tag]):
 @pytest.mark.sphinx(
     "html",
     testroot="defaults",
-    copy_files={
-        "_images/tux.png": "sub/pictures/tux.png",
-    },
+    copy_files=[
+        ("_images/tux.png", "sub/pictures/tux.png"),
+    ],
     write_docs={
         "index.rst": dedent("""
             .. thumb-image:: _images/tux.png

--- a/tests/unit_tests/test_target_format.py
+++ b/tests/unit_tests/test_target_format.py
@@ -130,9 +130,9 @@ def test_target_format(monkeypatch: pytest.MonkeyPatch, app: SphinxTestApp):
     "html",
     testroot="defaults",
     confoverrides={"thumb_image_resize_width": 100},
-    copy_files={
-        "_images/tux.png": "sub/pictures/tux.png",
-    },
+    copy_files=[
+        ("_images/tux.png", "sub/pictures/tux.png"),
+    ],
     write_docs={
         "sub/sub.rst": dedent("""
             :orphan:\n


### PR DESCRIPTION
Keeping it as a dict prevents one source file from being copied to more than one target path.