### PR TITLE
Handle images with no file extensions.

### DIFF
--- a/sphinx_thumb_image/resize.py
+++ b/sphinx_thumb_image/resize.py
@@ -51,7 +51,7 @@ class ThumbImageResize:
                     if target.exists():
                         return target
                     log.debug(f"resizing {source} ({source_size[0]}x{source_size[1]}) to {target}")
-                    image.save(target)
+                    image.save(target, format=image.format)
             except LockException:
                 return target
         return target

--- a/tests/unit_tests/__init__.py
+++ b/tests/unit_tests/__init__.py
@@ -2,6 +2,5 @@
 
 TODO::
 - Test dir/image.* (asset.py)
-- Test file with no extension?
 - Test using relative and absolute paths in directives
 """

--- a/tests/unit_tests/test_paths.py
+++ b/tests/unit_tests/test_paths.py
@@ -71,6 +71,7 @@ def test_efficient(outdir: Path, img_tags: list[element.Tag]):
     testroot="defaults",
     copy_files=[
         ("_images/tux.png", "sub/pictures/tux.png"),
+        ("_images/tux.png", "sub/pictures/x_no_ext"),
     ],
     write_docs={
         "index.rst": dedent("""
@@ -80,6 +81,8 @@ def test_efficient(outdir: Path, img_tags: list[element.Tag]):
         "sub/sub.rst": dedent("""
             :orphan:\n
             .. thumb-image:: pictures/tux.png
+                :resize-width: 100
+            .. thumb-image:: pictures/x_no_ext
                 :resize-width: 100
         """),
     },
@@ -114,10 +117,12 @@ def test_doctrees_paths(monkeypatch: pytest.MonkeyPatch, app: SphinxTestApp):
     assert open_paths == [
         Path("_images/tux.png"),
         Path("sub/pictures/tux.png"),
+        Path("sub/pictures/x_no_ext"),
     ]
     assert save_paths == [
         Path("_build/doctrees/_thumbs/_images/tux.100x118.png"),
         Path("_build/doctrees/_thumbs/sub/pictures/tux.100x118.png"),
+        Path("_build/doctrees/_thumbs/sub/pictures/x_no_ext.100x118"),
     ]
 
     # Check doctreedir contents.
@@ -128,4 +133,5 @@ def test_doctrees_paths(monkeypatch: pytest.MonkeyPatch, app: SphinxTestApp):
         Path("sub"),
         Path("sub/pictures"),
         Path("sub/pictures/tux.100x118.png"),
+        Path("sub/pictures/x_no_ext.100x118"),
     ]


### PR DESCRIPTION
Supported by Sphinx, should work in the extension as well.