### PR TITLE
Show node URI in warning

### DIFF
--- a/sphinx_thumb_image/resize.py
+++ b/sphinx_thumb_image/resize.py
@@ -63,7 +63,8 @@ class ThumbImageResize:
                 image.thumbnail((request.width or source_size[0], request.height or source_size[1]))
                 target_size = image.size
             if target_size[0] >= source_size[0]:
-                message = f"requested thumbnail size is not smaller than source image ({source_size[0]}x{source_size[1]})"
+                paren = f"{node['uri']} {source_size[0]}x{source_size[1]}"
+                message = f"requested thumbnail size is not smaller than source image ({paren})"
                 doctree.reporter.warning(message, source=node.source, line=node.line)
                 copy_instead_of_save = True
             else:


### PR DESCRIPTION
For https://github.com/Robpol86/sphinx-thumb-image/issues/52

Not sure yet why sometimes there is a line number of 0 when it's not and sometimes no line number at all. Might be a Sphinx bug since I don't construct the node in this extension. For now just adding the source path in the warning so it's easier to locate the trouble directive in the document.