### PR TITLE
Allow user to specify PIL save quality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Added new directive `list-table-thumbs` ([#72](https://github.com/Robpol86/sphinx-thumb-image/issues/72))
+- Added `:resize-quality:` directive option ([#28](https://github.com/Robpol86/sphinx-thumb-image/issues/28))
 
 ## [0.3.0] - 2026-01-26
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -72,7 +72,8 @@ Images
     .. rst:directive:option:: resize-quality
 
         An integer between 1 and 100 that overrides the
-        [default image save quality](https://pillow.readthedocs.io/en/stable/handbook/image-file-formats.html) used by PIL.
+        `default image save quality <https://pillow.readthedocs.io/en/stable/handbook/image-file-formats.html#jpeg-saving>`__
+        used by PIL.
 
     .. rst:directive:option:: no-resize-quality
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -69,6 +69,14 @@ Images
         Does not resize the image and instead just copies it to the output documentation directory. Useful when you want to
         use the other features in the extension for images that are already small.
 
+    .. rst:directive:option:: resize-quality
+
+        TODO
+
+    .. rst:directive:option:: no-resize-quality
+
+        Boolean option to negate :rst:dir:`thumb-image:resize-quality` if :option:`thumb_image_resize_quality` is set.
+
     .. rst:directive:option:: is-animated
 
         Boolean option that indicates the image is animated (e.g. an animated GIF).
@@ -234,6 +242,12 @@ Set defaults for the extension in your ``conf.py`` file:
     be overridden with the :rst:dir:`thumb-image:resize-height` option in the directive in document files. If
     :option:`thumb_image_resize_width` and :option:`thumb_image_resize_height` are both set the thumbnail will retain its
     aspect ratio and fit within both dimensions.
+
+.. option:: thumb_image_resize_quality
+
+    *Default:* :guilabel:`None`
+
+    TODO
 
 .. option:: thumb_image_is_animated
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -71,7 +71,8 @@ Images
 
     .. rst:directive:option:: resize-quality
 
-        TODO
+        An integer between 1 and 100 that overrides the
+        [default image save quality](https://pillow.readthedocs.io/en/stable/handbook/image-file-formats.html) used by PIL.
 
     .. rst:directive:option:: no-resize-quality
 
@@ -247,7 +248,7 @@ Set defaults for the extension in your ``conf.py`` file:
 
     *Default:* :guilabel:`None`
 
-    TODO
+    Sets :rst:dir:`thumb-image:resize-quality` by default for all thumb directives if set.
 
 .. option:: thumb_image_is_animated
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -76,7 +76,7 @@ Images
 
     .. rst:directive:option:: no-resize-quality
 
-        Boolean option to negate :rst:dir:`thumb-image:resize-quality` if :option:`thumb_image_resize_quality` is set.
+        Boolean option to ignore :option:`thumb_image_resize_quality` if it is set.
 
     .. rst:directive:option:: is-animated
 

--- a/sphinx_thumb_image/__init__.py
+++ b/sphinx_thumb_image/__init__.py
@@ -26,6 +26,7 @@ def setup(app: Sphinx) -> dict[str, str]:
     """
     app.add_config_value("thumb_image_resize_width", None, "env")
     app.add_config_value("thumb_image_resize_height", None, "env")
+    app.add_config_value("thumb_image_resize_quality", None, "env")
     app.add_config_value("thumb_image_is_animated", False, "env")
     app.add_config_value("thumb_image_target_format", False, "env")
     app.add_config_value("thumb_image_target_format_substitutions", {}, "env")

--- a/sphinx_thumb_image/directives.py
+++ b/sphinx_thumb_image/directives.py
@@ -16,6 +16,8 @@ class ThumbCommon(Image):
     __option_spec = {}
     __option_spec["resize-width"] = lambda arg: directives.nonnegative_int(arg.replace("px", ""))
     __option_spec["resize-height"] = __option_spec["resize-width"]
+    __option_spec["resize-quality"] = directives.percentage
+    __option_spec["no-resize-quality"] = directives.flag
     __option_spec["no-resize"] = directives.flag
     __option_spec["is-animated"] = directives.flag
     __option_spec["no-is-animated"] = directives.flag
@@ -71,7 +73,7 @@ class ThumbCommon(Image):
         else:
             self.options["target"] = target
 
-    def __add_request(self, sphinx_nodes: list[nodes.Element]) -> list[nodes.Element]:
+    def __add_request(self, sphinx_nodes: list[nodes.Element]) -> list[nodes.Element]:  # noqa: PLR0912
         """Build and add a ThumbRequest to the image node.
 
         :param sphinx_nodes: List of nodes returned by super().run(), one of which contains an image node to be modified.
@@ -104,10 +106,20 @@ class ThumbCommon(Image):
                 # User has not provided the width/height.
                 raise self.error('Error in %r directive: "resize-width" option is missing.' % self.name)
 
+        # Determine quality percentage.
+        if "no-resize-quality" in self.options:
+            pass
+        elif "resize-quality" in self.options:
+            request.quality = self.options["resize-quality"]
+        else:
+            thumb_image_resize_quality = config["thumb_image_resize_quality"]
+            if thumb_image_resize_quality is not None:
+                request.quality = thumb_image_resize_quality
+
         # Determine is_animated flag.
-        if "is-animated" in self.options:
-            request.is_animated = True
-        elif config["thumb_image_is_animated"] and "no-is-animated" not in self.options:
+        if "no-is-animated" in self.options:
+            pass
+        elif "is-animated" in self.options or config["thumb_image_is_animated"]:
             request.is_animated = True
 
         # Add request to the node.

--- a/sphinx_thumb_image/lib.py
+++ b/sphinx_thumb_image/lib.py
@@ -14,6 +14,7 @@ class ThumbNodeRequest:
 
     width: Optional[int] = None
     height: Optional[int] = None
+    quality: Optional[int] = None
     no_resize: bool = False
     is_animated: bool = False
 

--- a/sphinx_thumb_image/resize.py
+++ b/sphinx_thumb_image/resize.py
@@ -21,19 +21,20 @@ class ThumbImageResize:
     THUMBS_SUBDIR = "_thumbs"
 
     @classmethod
-    def save_animated(cls, image: PIL.ImageFile.ImageFile, target: Path, target_size: tuple[int, int]):
+    def save_animated(cls, image: PIL.ImageFile.ImageFile, target: Path, target_size: tuple[int, int], **kwargs):
         """Save all frames in an animated image file to the target file.
 
         :param image: Opened source image.
         :param target: Path to target file.
         :param target_size: Image width and height to resize to.
+        :param kwargs: TODO
         """
         frames = []
         for frame in PIL.ImageSequence.Iterator(image):
             frame_resized = frame.resize(target_size)
             frames.append(frame_resized)
         disposal = 2  # https://github.com/Robpol86/sphinx-thumb-image/issues/43
-        frames[0].save(target, format=image.format, save_all=True, append_images=frames[1:], disposal=disposal)
+        frames[0].save(target, save_all=True, append_images=frames[1:], disposal=disposal, **kwargs)
 
     @classmethod
     def resize(
@@ -83,10 +84,13 @@ class ThumbImageResize:
                         log.debug(f"skipping {source} ({target} exists after lock)")
                         return target
                     log.debug(f"resizing {source} ({source_size[0]}x{source_size[1]}) to {target}")
+                    kwargs = dict(format=image.format)
+                    if request.quality is not None:
+                        kwargs["quality"] = request.quality
                     if request.is_animated:
-                        cls.save_animated(image, target, target_size)
+                        cls.save_animated(image, target, target_size, **kwargs)
                     else:
-                        image.save(target, format=image.format)
+                        image.save(target, **kwargs)
             except LockException:
                 log.debug(f"skipping {source} ({target} exists after race)")
                 return target

--- a/sphinx_thumb_image/resize.py
+++ b/sphinx_thumb_image/resize.py
@@ -27,7 +27,7 @@ class ThumbImageResize:
         :param image: Opened source image.
         :param target: Path to target file.
         :param target_size: Image width and height to resize to.
-        :param kwargs: TODO
+        :param kwargs: Pass additional keyword arguments to PIL.save().
         """
         frames = []
         for frame in PIL.ImageSequence.Iterator(image):

--- a/sphinx_thumb_image/resize.py
+++ b/sphinx_thumb_image/resize.py
@@ -70,7 +70,10 @@ class ThumbImageResize:
                 doctree.reporter.warning(message, source=node.source, line=node.line)
                 return None
             # Get target file path.
-            thumb_file_name = f"{source.stem}.{target_size[0]}x{target_size[1]}{source.suffix}"
+            if request.quality:
+                thumb_file_name = f"{source.stem}.{target_size[0]}x{target_size[1]}.{request.quality}{source.suffix}"
+            else:
+                thumb_file_name = f"{source.stem}.{target_size[0]}x{target_size[1]}{source.suffix}"
             target = target_dir / thumb_file_name
             if target.exists():
                 log.debug(f"skipping {source} ({target} exists)")
@@ -85,7 +88,7 @@ class ThumbImageResize:
                         return target
                     log.debug(f"resizing {source} ({source_size[0]}x{source_size[1]}) to {target}")
                     kwargs = dict(format=image.format)
-                    if request.quality is not None:
+                    if request.quality:
                         kwargs["quality"] = request.quality
                     if request.is_animated:
                         cls.save_animated(image, target, target_size, **kwargs)


### PR DESCRIPTION
Adding the `:resize-quality:` directive option for this, with corresponding negating option and conf.py setting.

Fixes https://github.com/Robpol86/sphinx-thumb-image/issues/28
